### PR TITLE
Shadergraph Materials Import and Preview

### DIFF
--- a/cmake/IncludeShaderGraph.cmake
+++ b/cmake/IncludeShaderGraph.cmake
@@ -38,6 +38,7 @@ set(SRCS
 	src/shadergraph/graphnode.cpp
 	src/shadergraph/graphnodescene.cpp
 	src/shadergraph/shaderassetwidget.cpp
+	src/shadergraph/assets.cpp
 	src/shadergraph/core/materialhelper.cpp
 	src/shadergraph/core/undoredo.cpp
     #graphtest.cpp
@@ -90,6 +91,7 @@ set(HEADERS
 		src/shadergraph/graphnode.h
 		src/shadergraph/graphnodescene.h
 		src/shadergraph/shaderassetwidget.h
+		src/shadergraph/assets.h
 		src/shadergraph/core/materialhelper.h
 		src/shadergraph/core/undoredo.h
         #graphtest.h

--- a/src/io/materialreader.hpp
+++ b/src/io/materialreader.hpp
@@ -35,8 +35,9 @@ enum class TextureSource
 class MaterialReader : public AssetIOBase
 {
 	TextureSource textureSource;
+	QString globalSourceFolder;
 public:
-    MaterialReader(TextureSource texSrc = TextureSource::Project);
+    MaterialReader(TextureSource texSrc = TextureSource::Project, QString globalSourceFolder = "");
 
     void readJahShader(const QString &filePath);
     QJsonObject getParsedShader();
@@ -44,9 +45,9 @@ public:
 	// if handle is null then it will try to fetch the assets
 	// from the asset manager
 	iris::CustomMaterialPtr parseMaterial(QJsonObject matObject, Database* handle, bool loadTextures = true);
-	iris::CustomMaterialPtr createMaterialFromShaderGuid(QString shaderGuid);
+	iris::CustomMaterialPtr createMaterialFromShaderGuid(QString shaderGuid, Database* db);
 	iris::CustomMaterialPtr createMaterialFromShaderFile(QString shaderPath, Database* db);
-	QJsonObject getShaderObjectFromId(QString shaderGuid);
+	QJsonObject getShaderObjectFromId(QString shaderGuid, Database* db);
 	iris::CustomMaterialPtr loadMaterialV2(QJsonObject matObject, Database* handle);
 	iris::CustomMaterialPtr loadMaterialV1(QJsonObject matObject, Database* handle);
 	QJsonObject convertV1MaterialToV2(QJsonObject mat);
@@ -60,8 +61,10 @@ private:
 // used by material reader to create a material from a shader
 class ShaderHandler : public AssetIOBase
 {
+	TextureSource textureSource;
+	QString globalSourceFolder;
 public:
-	ShaderHandler();
+	ShaderHandler(TextureSource texSrc = TextureSource::Project, QString globalSourceFolder = "");
 
 	iris::CustomMaterialPtr loadMaterialFromShader(QJsonObject shaderObject, Database* handle);
 	iris::CustomMaterialPtr loadMaterialFromShaderV2(QJsonObject shaderObject, Database* handle);

--- a/src/widgets/assetview.cpp
+++ b/src/widgets/assetview.cpp
@@ -1713,6 +1713,7 @@ void AssetView::addAssetItemToProject(AssetGridItem *item)
     if (jafType == ModelTypes::Material) {
         QJsonDocument matDoc = QJsonDocument::fromBinaryData(db->fetchAssetData(guidReturned));
         QJsonObject matObject = matDoc.object();
+		qDebug() << matObject["guid"];
         //iris::CustomMaterialPtr material = iris::CustomMaterialPtr::create();
 
 		MaterialReader reader;

--- a/src/widgets/assetviewer.cpp
+++ b/src/widgets/assetviewer.cpp
@@ -363,7 +363,7 @@ void AssetViewer::addJafMaterial(const QString &guid, bool firstAdd, bool cache,
     QJsonObject matObject = matDoc.object();
     //iris::CustomMaterialPtr material = iris::CustomMaterialPtr::create();
 
-	MaterialReader reader(TextureSource::GlobalAssets);
+	MaterialReader reader(TextureSource::GlobalAssets, guid);
 	qDebug() << matDoc.toJson(QJsonDocument::Indented);
 	auto material = reader.parseMaterial(matObject, db);
 

--- a/src/widgets/propertywidgets/materialpropertywidget.cpp
+++ b/src/widgets/propertywidgets/materialpropertywidget.cpp
@@ -127,7 +127,7 @@ void MaterialPropertyWidget::materialChanged(int index)
     clearPanel(this->layout());
 
 	MaterialReader reader;
-	material = reader.createMaterialFromShaderGuid(materialSelector->getCurrentItemData());
+	material = reader.createMaterialFromShaderGuid(materialSelector->getCurrentItemData(), db);
     material->setName(materialSelector->getCurrentItem());
     material->setGuid(materialSelector->getCurrentItemData());
 	meshNode->setMaterial(material);


### PR DESCRIPTION
Shadergraph materials can now be imported into the asset module.
You can now change the mesh in the preview window in the effects module.